### PR TITLE
Fixed return value of GetServerOptions when err

### DIFF
--- a/pkg/credentials/grpc_test.go
+++ b/pkg/credentials/grpc_test.go
@@ -24,10 +24,8 @@ func TestServerOptions(t *testing.T) {
 			Cert:   []byte(nil),
 			Key:    []byte(nil),
 		}
-		opts, err := GetServerOptions(chain)
-		assert.Nil(t, err)
-		assert.Nil(t, opts)
-		assert.Len(t, opts, 0)
+		_, err := GetServerOptions(chain)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Fixes the test failure in https://github.com/dapr/dapr/pull/4555